### PR TITLE
Fix step types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Added all generated `_type` values to the single step of the integration.

--- a/src/steps/fetch-users/index.ts
+++ b/src/steps/fetch-users/index.ts
@@ -17,7 +17,18 @@ import { createDuoClient } from '../../collector';
 const step: IntegrationStep = {
   id: 'fetch-users',
   name: 'Fetch Users',
-  types: ['duo-user'],
+  types: [
+    'duo_account',
+    'duo_admin',
+    'duo_user',
+    'duo_group',
+    'mfa_device',
+    'duo_account_has_group',
+    'duo_account_has_admin',
+    'duo_account_has_user',
+    'duo_group_has_user',
+    'duo_user_assigned_device',
+  ],
   async executionHandler({
     instance,
     jobState,


### PR DESCRIPTION
Each step needs to declare the generated `_type`s it is responsible for so the synchronizer can know when a failure has occurred and avoid deleting graph objects.